### PR TITLE
Fix IP detection for latest Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ jobs:
     - stage: test
       name: 'Ubuntu 18.04 LTS (Bionic Beaver)  [GOAL: install]'
       script:
-         - travis_retry sudo docker run --cap-add=NET_ADMIN --rm=true -v `pwd`:/veles-masternode:rw ubuntu:18.04 /bin/bash -c "apt-get update ; apt-get install -q -y wget curl make procps python ; cd /veles-masternode/; make docker_test_install"
+         - travis_retry sudo docker run --cap-add=NET_ADMIN --rm=true -v `pwd`:/veles-masternode:rw ubuntu:18.04 /bin/bash -c "apt-get update ; apt-get install -q -y wget curl make procps python dnsutils; cd /veles-masternode/; make docker_test_install"
     - stage: test
       name: 'Ubuntu 19.04 (Disco Dingo), update [GOAL: install] '
       script:
-         - travis_retry sudo docker run --cap-add=NET_ADMIN --rm=true -v `pwd`:/veles-masternode:rw ubuntu:19.04 /bin/bash -c "apt-get update ; apt-get install -q -y wget curl make procps python ; cd /veles-masternode/; make docker_test_install"
+         - travis_retry sudo docker run --cap-add=NET_ADMIN --rm=true -v `pwd`:/veles-masternode:rw ubuntu:19.04 /bin/bash -c "apt-get update ; apt-get install -q -y wget curl make procps python dnsutils; cd /veles-masternode/; make docker_test_install"
     - stage: test
       name: 'Linux Mint [latest]  [GOAL: install]'
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
       name: 'Ubuntu [xenial]  [GOAL: install, update]'
       script:
          - travis_retry sudo make test_install && sudo make test_install
-     - stage: test
+    - stage: test
       name: 'Ubuntu 18.04 LTS (Bionic Beaver)  [GOAL: install]'
       script:
          - travis_retry sudo docker run --cap-add=NET_ADMIN --rm=true -v `pwd`:/veles-masternode:rw ubuntu:18.04 /bin/bash -c "apt-get update ; apt-get install -q -y wget curl make procps python ; cd /veles-masternode/; make docker_test_install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: bionic
 language: bash
 script: make test
 stages:
@@ -10,6 +10,14 @@ jobs:
       name: 'Ubuntu [xenial]  [GOAL: install, update]'
       script:
          - travis_retry sudo make test_install && sudo make test_install
+     - stage: test
+      name: 'Ubuntu 18.04 LTS (Bionic Beaver)  [GOAL: install]'
+      script:
+         - travis_retry sudo docker run --cap-add=NET_ADMIN --rm=true -v `pwd`:/veles-masternode:rw ubuntu:18.04 /bin/bash -c "apt-get update ; apt-get install -q -y wget curl make procps python ; cd /veles-masternode/; make docker_test_install"
+    - stage: test
+      name: 'Ubuntu 19.04 (Disco Dingo), update [GOAL: install] '
+      script:
+         - travis_retry sudo docker run --cap-add=NET_ADMIN --rm=true -v `pwd`:/veles-masternode:rw ubuntu:19.04 /bin/bash -c "apt-get update ; apt-get install -q -y wget curl make procps python ; cd /veles-masternode/; make docker_test_install"
     - stage: test
       name: 'Linux Mint [latest]  [GOAL: install]'
       script:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Veles Masternode Installer script can be safely run on any platform, and will wo
 
 If your system is not supported, running this script has **no** side effects - thanks to extensive dependency checking, it will simply exit with an error message containing hints onto which commands/packages are missing on your system and how to install them.
 
+*Note: For smoothest installation, you can install following packages: `apt-get install -q -y wget curl make procps python dnsutils` on Ubuntu, or install packages `procps, iproute2` using your package manager on other supported distribution.
+*
+
 ### Officially Supported
 * Ubuntu
 * Debian

--- a/masternode.sh
+++ b/masternode.sh
@@ -33,7 +33,7 @@ declare -A APT_PACKAGES
 declare -A YUM_PACKAGES
 declare -A EMERGE_PACKAGES
 declare -A EQUO_PACKAGES
-APT_PACKAGES=(["ps"]="procps" ["ifconfig"]="net-tools" ["ip"]="iproute2" ["dig"]="dig") # net-tools will once be deprecated on all distros, it's fallback for old systems
+APT_PACKAGES=(["ps"]="procps" ["ifconfig"]="net-tools" ["ip"]="iproute2" ["dig"]="dnsutils") # net-tools will once be deprecated on all distros, it's fallback for old systems
 YUM_PACKAGES=(["ps"]="procps" ["ip"]="iproute")
 EMERGE_PACKAGES=(["ps"]="procps" ["ip"]="iproute2")
 EQUO_PACKAGES=(["ps"]="procps" ["ip"]="iproute2")


### PR DESCRIPTION
Fix IP detection for Ubuntu 18.04 and 19.04 and add CI tests for these Ubuntu releases. Based on method ported from gen2 masternode installer. 